### PR TITLE
Fixed includes in all files.

### DIFF
--- a/src/actors.cpp
+++ b/src/actors.cpp
@@ -1,4 +1,7 @@
-#include "common.h"
+#include "actors.h"
+#include "math.h"
+#include "tiles.h"
+
 #define shadow_scalefactor 1.5f
 #define shadowminsize 1.1f
 

--- a/src/actors.h
+++ b/src/actors.h
@@ -1,6 +1,7 @@
 #ifndef ACTORS_H_INCLUDED
 #define ACTORS_H_INCLUDED
 
+#include "common.h"
 #include "geometry.h"
 
 extern bool YE_Shadows;

--- a/src/common.h
+++ b/src/common.h
@@ -1,9 +1,10 @@
 #ifndef COMMON_H_INCLUDED
 #define COMMON_H_INCLUDED
-#define GL_MULTISAMPLE 0x809D
+
 
 #include "glew.h"
 #include <GL/gl.h>
+
 #include <SDL/SDL.h>
 #include "SDL_image.h"
 
@@ -15,15 +16,7 @@
 #include <map>
 #include <vector>
 
-#include "actors.h"
-#include "tiles.h"
-#include "map.h"
-#include "renderer.h"
-#include "strings.h"
 #include "tinydir.h"
-#include "log.h"
-#include "geometry.h"
-#include "math.h"
 
 using std::min;
 using std::max;

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "geometry.h"
 
 bool operator==(Vector2i a, Vector2i b)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,10 @@
 /* Yay Evil 2.0 */
 /*              */
 
-#include "common.h"
+#include "map.h"
+#include "math.h"
+#include "log.h"
+#include "renderer.h"
 
 #define screen_width_min 640
 #define screen_height_min 480

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1,6 +1,8 @@
-#include "common.h"
-#define GL_BGR 0x80E0
-#define GL_BGRA 0x80E1
+#include "map.h"
+
+#include "log.h"
+#include "math.h"
+#include "strings.h"
 
 YE_Map::YE_Map()
 {

--- a/src/map.h
+++ b/src/map.h
@@ -1,7 +1,9 @@
 #ifndef MAP_H_INCLUDED
 #define MAP_H_INCLUDED
 
+#include "actors.h"
 #include "geometry.h"
+#include "tiles.h"
 
 class YE_Map
 {

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 
 #include "geometry.h"
+#include "renderer.h"
 
 float tiles_width, tiles_height, half_width, half_height;
 int index;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -1,6 +1,8 @@
 #ifndef RENDERER_H_INCLUDED
 #define RENDERER_H_INCLUDED
 
+#include "map.h"
+
 extern float cam_x, cam_y;
 extern int screen_width, screen_height;
 extern YE_Map stmap;

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -1,5 +1,7 @@
 #include "common.h"
 
+#include "log.h"
+
 FILE* file;
 
 bool YE_EndsWith(const char *str, const char *ending)

--- a/src/tiles.cpp
+++ b/src/tiles.cpp
@@ -1,4 +1,6 @@
-#include "common.h"
+#include "tiles.h"
+
+#include "map.h"
 
 #define AO_size 0.25
 #define AO_color 0.2f

--- a/src/tiles.h
+++ b/src/tiles.h
@@ -1,6 +1,8 @@
 #ifndef TILES_H_INCLUDED
 #define TILES_H_INCLUDED
 
+#include "common.h"
+
 extern std::map<std::string, GLuint> Textures;
 
 class Tile


### PR DESCRIPTION
Only libraries should be put in common.h

If you put all headers in common.h, you must order the headers manually so that later headers use stuff from the earlier ones. Also, it means you need to fully recompile the project if you change any header.

This all sucks and you should just include what is needed in every file. Also, every .cpp file must start from including its corresponding .h file.
